### PR TITLE
Allow Fable and other discovered quotas in tray indicators

### DIFF
--- a/src/provider_registry.rs
+++ b/src/provider_registry.rs
@@ -328,6 +328,25 @@ pub fn settings_brick_ids(
     ids
 }
 
+/// Tray selectors contain quota metrics only, including API-discovered windows.
+pub fn tray_metric_options(
+    provider: ProviderKind,
+    discovered_labels: &std::collections::BTreeMap<String, String>,
+) -> Vec<(String, String)> {
+    let mut options = descriptor(provider)
+        .metrics
+        .iter()
+        .map(|metric| (metric.id.to_string(), metric.label.to_string()))
+        .collect::<Vec<_>>();
+    let prefix = format!("{}.additional.", descriptor(provider).id);
+    for (id, label) in discovered_labels {
+        if id.starts_with(&prefix) && !options.iter().any(|(known, _)| known == id) {
+            options.push((id.clone(), label.clone()));
+        }
+    }
+    options
+}
+
 /// Prefer the live provider title for a discovered additional window.
 pub fn settings_brick_label(
     provider: ProviderKind,
@@ -475,6 +494,51 @@ pub fn resolve_metric<'a>(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn tray_options_include_dynamic_windows_and_resolve_the_selected_quota() {
+        let limits = RateLimits {
+            additional_limits: vec![crate::limits::AdditionalLimit {
+                id: "claude-weekly-scoped-claude-fable-5-promo".into(),
+                title: "Fable only".into(),
+                window: LimitWindow {
+                    used_percent: Some(42),
+                    duration_minutes: Some(10080),
+                    ..Default::default()
+                },
+            }],
+            ..Default::default()
+        };
+        let mut labels = discovered_additional_brick_labels(ProviderKind::Claude, &limits)
+            .into_iter()
+            .collect::<std::collections::BTreeMap<_, _>>();
+        labels.insert("codex.additional.other".into(), "Other provider".into());
+        labels.insert("claude.usage".into(), "Usage stats".into());
+        let options = tray_metric_options(ProviderKind::Claude, &labels);
+        assert_eq!(options.len(), CLAUDE_METRICS.len() + 1);
+        let (id, label) = options.last().unwrap();
+        assert_eq!(label, "Fable only");
+        let (resolved_id, _, window) = resolve_metric(ProviderKind::Claude, &limits, id).unwrap();
+        assert_eq!(&resolved_id, id);
+        assert_eq!(window.used_percent, Some(42));
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("settings.toml");
+        let mut settings = crate::settings::Settings::default();
+        let mut widget = crate::settings::TrayWidget::custom_for_provider(ProviderKind::Claude);
+        widget.indicators[0].metric_id = id.clone();
+        settings.tray_widgets = vec![widget];
+        settings.save(&path).unwrap();
+        let loaded = crate::settings::Settings::load_or_create(&path).unwrap();
+        assert_eq!(&loaded.tray_widgets[0].indicators[0].metric_id, id);
+        assert_eq!(
+            tray_metric_options(ProviderKind::Codex, &labels).len(),
+            CODEX_METRICS.len() + 1
+        );
+        assert_eq!(
+            tray_metric_options(ProviderKind::Claude, &Default::default()).len(),
+            CLAUDE_METRICS.len()
+        );
+    }
 
     #[test]
     fn registry_covers_every_provider_exactly_once() {

--- a/src/settings_window/tray.rs
+++ b/src/settings_window/tray.rs
@@ -96,9 +96,11 @@ fn tray_indicator_summary(indicator: &TrayIndicator) -> String {
     let Some(provider) = indicator.provider() else {
         return format!("Unsupported {}", indicator.provider_id);
     };
-    let metric = crate::provider_registry::metric(provider, &indicator.metric_id)
-        .map(|metric| metric.label.to_owned())
-        .unwrap_or_else(|| indicator.metric_id.clone());
+    let metric = crate::provider_registry::settings_brick_label(
+        provider,
+        &indicator.metric_id,
+        &cached_discovered_popup_bricks(),
+    );
     let value = match indicator.limit_value {
         LimitValue::Used => "Used",
         LimitValue::Remaining => "Remaining",
@@ -851,14 +853,17 @@ fn tray_time_parameter_fields(
             provider_labels.len() - 1
         }) as i32;
     let metric_provider = known_provider.unwrap_or(ProviderKind::Codex);
-    let metrics = crate::provider_registry::descriptor(metric_provider).metrics;
+    let metrics = crate::provider_registry::tray_metric_options(
+        metric_provider,
+        &cached_discovered_popup_bricks(),
+    );
     let mut metric_labels = metrics
         .iter()
-        .map(|metric| metric.label.to_owned())
+        .map(|(_, label)| label.clone())
         .collect::<Vec<_>>();
     let metric_index = metrics
         .iter()
-        .position(|metric| metric.id == indicator.metric_id)
+        .position(|(id, _)| id == &indicator.metric_id)
         .unwrap_or_else(|| {
             metric_labels.push(format!("Unavailable ({})", indicator.metric_id));
             metric_labels.len() - 1
@@ -911,14 +916,17 @@ fn tray_time_parameter_fields(
             widget.id, indicator.provider_id
         ))
         .on_selection_changed(move |choice: i32| {
-            let Some(metric) = metrics.get(choice.max(0) as usize) else {
+            let Some(metric) = usize::try_from(choice)
+                .ok()
+                .and_then(|index| metrics.get(index))
+            else {
                 return;
             };
             let mut next = widgets_for_metric.clone();
             if next[widget_index].indicators.is_empty() {
                 return;
             }
-            next[widget_index].indicators[indicator_index].metric_id = metric.id.into();
+            next[widget_index].indicators[indicator_index].metric_id = metric.0.clone();
             persist_tray_widgets(
                 metric_setter.clone(),
                 metric_tx.clone(),
@@ -1301,14 +1309,17 @@ fn tray_indicator_edit_form(
             provider_labels.len() - 1
         }) as i32;
     let metric_provider = known_provider.unwrap_or(ProviderKind::Codex);
-    let metrics = crate::provider_registry::descriptor(metric_provider).metrics;
+    let metrics = crate::provider_registry::tray_metric_options(
+        metric_provider,
+        &cached_discovered_popup_bricks(),
+    );
     let mut metric_labels = metrics
         .iter()
-        .map(|metric| metric.label.to_owned())
+        .map(|(_, label)| label.clone())
         .collect::<Vec<_>>();
     let metric_index = metrics
         .iter()
-        .position(|metric| metric.id == indicator.metric_id)
+        .position(|(id, _)| id == &indicator.metric_id)
         .unwrap_or_else(|| {
             metric_labels.push(format!("Unavailable ({})", indicator.metric_id));
             metric_labels.len() - 1
@@ -1392,11 +1403,14 @@ fn tray_indicator_edit_form(
             widget.id, indicator.provider_id
         ))
         .on_selection_changed(move |choice: i32| {
-            let Some(metric) = metrics.get(choice.max(0) as usize) else {
+            let Some(metric) = usize::try_from(choice)
+                .ok()
+                .and_then(|index| metrics.get(index))
+            else {
                 return;
             };
             let mut next = widgets_for_metric.clone();
-            next[widget_index].indicators[indicator_index].metric_id = metric.id.into();
+            next[widget_index].indicators[indicator_index].metric_id = metric.0.clone();
             persist_tray_widgets(
                 metric_setter.clone(),
                 metric_tx.clone(),


### PR DESCRIPTION
Claude can report model-specific quota windows such as **Fable only**, but the tray metric pickers only list the static catalog (5h session and Weekly). This makes an already-discovered quota impossible to select as a tray indicator.

This change includes provider-discovered quota windows in both the indicator editor and reset-time/countdown metric picker, using the provider's label and stable metric ID. It also shows those labels in indicator summaries and ignores invalid selection indices. The implementation works for additional quotas from any provider, without hardcoding Fable or changing the settings schema.

Validation:
- `cargo check --locked` and the Windows x64 release/package build passed.
- All 8 provider-registry tests passed, including a new regression covering Fable selection, quota resolution, settings save/reload, provider isolation, and exclusion of non-quota popup cards.
- The existing unknown-provider/metric round-trip test passed.
- Full `cargo test --lib --locked`: 236 passed, 3 failed, 1 ignored. Failures are `scheduler::tests::state_survives_restart`, `settings::tests::time_format_toml_names_round_trip`, and `store::tests::unchanged_codex_cache_does_not_rewrite_rows`; their source files are unchanged from the base branch.

Only the two implementation/test files are included; no fork-specific configuration or documentation changes.
